### PR TITLE
soften group endorsement

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # OCapN Test suite
 
-This repository contains a test suite for CapTP, OCapN netlayers & OCapN URIs as defined by the OCapN Pre-Standardization Group. The goal of this test suite is to ensure compliance with the CapTP specification and facilitate interoperation between different CapTP implementations.
+This repository contains a test suite for CapTP, OCapN netlayers & OCapN URIs, a work-in-progress of the OCapN Pre-Standardization Group. The goal of this test suite is to ensure compliance with the CapTP specification and facilitate interoperation between different CapTP implementations.
 
 ## Requirements
 


### PR DESCRIPTION
"defined by" suggests that the whole group defined this test suite. But so far it's more of a proposal from Spritely to the group, right?