### PR TITLE
TCP testing netlayer: do not bind to available port

### DIFF
--- a/test_runner.py
+++ b/test_runner.py
@@ -32,7 +32,7 @@ def setup_netlayer(ocapn_node):
         if url.port is None:
             raise Exception("All tcp-testing-only URIs require a port")
         else:
-            return TestingOnlyTCPNetlayer(url.hostname, url.port)
+            return TestingOnlyTCPNetlayer(url.hostname)
     else:
         raise ValueError(f"Unsupported transport layer: {ocapn_node.transport}")
 


### PR DESCRIPTION
The netlayer should be binding to an available port for itself and connecting to the URI provided by the user, not trying to bind to that port.