### PR TITLE
Move host and port into hints for tcp-testing-only netlayer

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ IT IS HIGHLY INSECURE, DO NOT USE IN PRODUCTION.
 TCP netlayer streams pure Syrup-encoded data directly, without any encryption or metadata apart from regular CapTP messages.
 It is simple to implement, and should be enough to get you through the tests.
 
-E.g `./test_runner.py 'ocapn://127.0.0.1:22045.tcp-testing-only'` will try to connect to port 22045 on the local host, and run tests on it.
+E.g `./test_runner.py 'ocapn://a2ef69ddd5f84840970612ff660f5058.tcp-testing-only?host=127.0.0.1&port=22045'` will try to connect to port 22045 on localhost, and run tests on it.
 
 ## Testing against an implementation
 

--- a/test_runner.py
+++ b/test_runner.py
@@ -28,11 +28,10 @@ def setup_netlayer(ocapn_node):
     if ocapn_node.transport == Symbol("onion"):
         return OnionNetlayer()
     elif ocapn_node.transport == Symbol("tcp-testing-only"):
-        url = urlparse(f"tcp-testing-only://{ocapn_node.address}")
-        if url.port is None:
+        if ocapn_node.hints.get("port") is None:
             raise Exception("All tcp-testing-only URIs require a port")
         else:
-            return TestingOnlyTCPNetlayer(url.hostname)
+            return TestingOnlyTCPNetlayer(ocapn_node.hints.get("host"))
     else:
         raise ValueError(f"Unsupported transport layer: {ocapn_node.transport}")
 


### PR DESCRIPTION
The tcp-testing-only netlayer used the OCapN locator URI format as follows:

```
ocapn://127.0.0.1:22045.tcp-testing-only
```

This isn't how URIs usually specify ports meaning we have to parse the port ourselves and can't use the libraries. If we were to move the port to `ocapn://127.0.0.1.tcp-testing-only:22045`, which is maybe more expected it leads to two problems. This does not conform to the [OCapN Locators specification](https://github.com/ocapn/ocapn/blob/main/draft-specifications/Locators.md) and the designator + transport layer (in this case "127.0.0.1" and "tcp-testing-only" no longer make a unique identifier for the node as it'd miss the port).

This PR changes the URI format so that the hints contain both the host and port information, the designator can be anything. It's just some unauthenticated unique string. This also better aligns with probably what most netlayers will do, as the designator usually wants to be something authenticated like a public key and the hints should be used to find the node. The new URI looks something like this:

```
ocapn://a2ef69ddd5f84840970612ff660f5058.tcp-testing-only?host=127.0.0.1&port=24680
```
