### PR TITLE
Rename OCapN node to OCapN peer

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This should be available at the swiss num: "IokCxYmMj04nos2JN1TDoY1bT8dXh6Lr"
 ## Sturdyref enlivener
 
 This takes a single argument which OCapN sturdyref object. The actor should
-"enliven" (connect to the node and get a live reference to the object)
+"enliven" (connect to the peer and get a live reference to the object)
 the sturdyref and then return that to the messager.
 
 This should be available at the swiss num: "gi02I1qghIwPiKGKleCQAOhpy3ZtYRpB"

--- a/netlayers/base.py
+++ b/netlayers/base.py
@@ -16,7 +16,7 @@ import socket
 
 from contrib import syrup
 from utils.captp_types import CapTPType, decode_captp_message
-from utils.ocapn_uris import OCapNNode
+from utils.ocapn_uris import OCapNPeer
 from utils.captp import CapTPSession
 
 
@@ -81,13 +81,13 @@ class CapTPSocket(socket.socket):
         return captp_socket
 
     def send_message(self, message):
-        """ Send data to the remote node """
+        """ Send data to the remote peer """
         if isinstance(message, CapTPType):
             message = message.to_syrup()
         self.sendall(message)
 
     def receive_message(self, timeout=120) -> CapTPType:
-        """ Receive data from the remote node """
+        """ Receive data from the remote peer """
         socketio = ReadSocketIO(self, timeout=timeout)
         encoded_message = syrup.syrup_read(socketio)
         assert isinstance(encoded_message, syrup.Record)
@@ -97,14 +97,14 @@ class CapTPSocket(socket.socket):
 class Netlayer(ABC):
     """ Base class for all netlayers """
 
-    location: OCapNNode
+    location: OCapNPeer
 
     @abstractmethod
-    def connect(self, ocapn_node: OCapNNode) -> CapTPSession:
-        """ Connect to a remote node returning a connection """
+    def connect(self, ocapn_peer: OCapNPeer) -> CapTPSession:
+        """ Connect to a remote peer returning a connection """
         pass
 
     @abstractmethod
     def accept(self) -> CapTPSession:
-        """ Accept a connection from a remote node returning a connection """
+        """ Accept a connection from a remote peer returning a connection """
         pass

--- a/netlayers/onion.py
+++ b/netlayers/onion.py
@@ -22,7 +22,7 @@ from contrib import syrup
 from netlayers.base import CapTPSocket, Netlayer
 
 import stem.process
-from utils.ocapn_uris import OCapNNode
+from utils.ocapn_uris import OCapNPeer
 
 from utils.captp import CapTPSession
 
@@ -146,10 +146,10 @@ class OnionNetlayer(Netlayer):
     def __del__(self):
         self.shutdown()
 
-    def connect(self, ocapn_node: OCapNNode) -> CapTPSession:
-        """ Connect to the remote node """
+    def connect(self, ocapn_peer: OCapNPeer) -> CapTPSession:
+        """ Connect to the remote peer """
         # Finally setup a socket and connect to the CapTP server
-        hidden_service_uri = f"{ocapn_node.address}.onion"
+        hidden_service_uri = f"{ocapn_peer.address}.onion"
         onion_sock = Socks5Proxy(self._unix_socket_path)
         onion_sock.connect(hidden_service_uri, self.PORT)
 
@@ -179,7 +179,7 @@ class OnionNetlayer(Netlayer):
             if data[-1] == ord("\n"):
                 return data
 
-    def add_hidden_service(self) -> Tuple[CapTPSocket, OCapNNode]:
+    def add_hidden_service(self) -> Tuple[CapTPSocket, OCapNPeer]:
         """ Add a hidden service to the Tor process """
         if self._control_socket is None:
             raise Exception("Cannot add a hidden service after the control socket has been closed")
@@ -215,10 +215,10 @@ class OnionNetlayer(Netlayer):
         incoming_control_socket.bind(ocapn_sock_path)
         incoming_control_socket.listen()
 
-        # Create the OCapNNode that represents this hidden service
-        ocapn_node = OCapNNode(syrup.Symbol("onion"), service_id, False)
+        # Create the OCapNPeer that represents this hidden service
+        ocapn_peer = OCapNPeer(syrup.Symbol("onion"), service_id, False)
 
-        return incoming_control_socket, ocapn_node
+        return incoming_control_socket, ocapn_peer
 
     def shutdown(self):
         """ Shuts down the netlayer """

--- a/netlayers/testing_only_tcp.py
+++ b/netlayers/testing_only_tcp.py
@@ -19,7 +19,7 @@ from urllib.parse import urlparse, urlunparse
 from contrib import syrup
 from netlayers.base import CapTPSocket, Netlayer
 
-from utils.ocapn_uris import OCapNNode
+from utils.ocapn_uris import OCapNPeer
 from utils.captp import CapTPSession
 
 class TestingOnlyTCPNetlayer(Netlayer):
@@ -46,9 +46,9 @@ class TestingOnlyTCPNetlayer(Netlayer):
         self._connections = []
 
         self.address, self.port = listen_address, listen_port
-        self.location = OCapNNode(
+        self.location = OCapNPeer(
             syrup.Symbol("tcp-testing-only"),
-            # This should be unique to the node, in most netlayers it'd be
+            # This should be unique to the peer, in most netlayers it'd be
             # authenticated so a key would work well here. In testing we don't
             # care, just some unique string will do.
             uuid.uuid4().hex,
@@ -59,11 +59,11 @@ class TestingOnlyTCPNetlayer(Netlayer):
     def __del__(self):
         self.shutdown()
 
-    def connect(self, ocapn_node: OCapNNode) -> CapTPSession:
-        """ Connect to the remote node """
+    def connect(self, ocapn_peer: OCapNPeer) -> CapTPSession:
+        """ Connect to the remote peer """
 
         loc_socket = socket.socket()
-        loc_socket.connect((ocapn_node.hints["host"], int(ocapn_node.hints["port"])))
+        loc_socket.connect((ocapn_peer.hints["host"], int(ocapn_peer.hints["port"])))
 
         connection = CapTPSocket.from_socket(loc_socket)
         self._connections.append(connection)

--- a/test_runner.py
+++ b/test_runner.py
@@ -17,23 +17,23 @@ import sys
 from urllib.parse import urlparse
 
 from contrib.syrup import Symbol
-from utils.ocapn_uris import OCapNNode
+from utils.ocapn_uris import OCapNPeer
 from utils.test_suite import CapTPTestRunner
 from netlayers.onion import OnionNetlayer
 from netlayers.testing_only_tcp import TestingOnlyTCPNetlayer
 
 
-def setup_netlayer(ocapn_node):
-    """ Setup the netlayer for the provided OCapN node """
-    if ocapn_node.transport == Symbol("onion"):
+def setup_netlayer(ocapn_peer):
+    """ Setup the netlayer for the provided OCapN peer """
+    if ocapn_peer.transport == Symbol("onion"):
         return OnionNetlayer()
-    elif ocapn_node.transport == Symbol("tcp-testing-only"):
-        if ocapn_node.hints.get("port") is None:
+    elif ocapn_peer.transport == Symbol("tcp-testing-only"):
+        if ocapn_peer.hints.get("port") is None:
             raise Exception("All tcp-testing-only URIs require a port")
         else:
-            return TestingOnlyTCPNetlayer(ocapn_node.hints.get("host"))
+            return TestingOnlyTCPNetlayer(ocapn_peer.hints.get("host"))
     else:
-        raise ValueError(f"Unsupported transport layer: {ocapn_node.transport}")
+        raise ValueError(f"Unsupported transport layer: {ocapn_peer.transport}")
 
 
 if __name__ == "__main__":
@@ -42,7 +42,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser()
     parser.add_argument(
         "locator",
-        help="OCapN Node locator to test against"
+        help="OCapN Peer locator to test against"
     )
     parser.add_argument(
         "--test-module",
@@ -64,17 +64,17 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # Parse and validate the address
-    ocapn_node_uri = OCapNNode.from_uri(args.locator)
+    ocapn_peer_uri = OCapNPeer.from_uri(args.locator)
 
     try:
-        netlayer = setup_netlayer(ocapn_node_uri)
+        netlayer = setup_netlayer(ocapn_peer_uri)
     except ImportError as e:
         print(f"Unable to setup netlayer: {e}")
         sys.exit(1)
 
     verbosity = 2 if args.verbose else 1
 
-    runner = CapTPTestRunner(netlayer, ocapn_node_uri, args.captp_version, verbosity=verbosity)
+    runner = CapTPTestRunner(netlayer, ocapn_peer_uri, args.captp_version, verbosity=verbosity)
     suite = runner.loadTests(args.test_module)
     result = runner.run(suite)
 

--- a/tests/third_party_handoffs.py
+++ b/tests/third_party_handoffs.py
@@ -19,7 +19,7 @@ import string
 
 from contrib.syrup import syrup_encode, Symbol
 from utils.test_suite import CapTPTestCase, retry_on_network_timeout
-from utils.ocapn_uris import OCapNNode, OCapNSturdyref
+from utils.ocapn_uris import OCapNPeer, OCapNSturdyref
 from utils import captp_types
 
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PrivateKey
@@ -33,14 +33,14 @@ class HandoffTestCase(CapTPTestCase):
         return netlayer_class()
 
     def _generate_two_keypairs(self):
-        """ Generate two keypairs to represent those of a session between two nodes """
-        node_a_private_key = Ed25519PrivateKey.generate()
-        node_b_private_key = Ed25519PrivateKey.generate()
+        """ Generate two keypairs to represent those of a session between two peers """
+        peer_a_private_key = Ed25519PrivateKey.generate()
+        peer_b_private_key = Ed25519PrivateKey.generate()
 
-        node_a_public_key = captp_types.CapTPPublicKey(node_a_private_key.public_key())
-        node_b_public_key = captp_types.CapTPPublicKey(node_b_private_key.public_key())
+        peer_a_public_key = captp_types.CapTPPublicKey(peer_a_private_key.public_key())
+        peer_b_public_key = captp_types.CapTPPublicKey(peer_b_private_key.public_key())
 
-        return node_a_public_key, node_a_private_key, node_b_public_key, node_b_private_key
+        return peer_a_public_key, peer_a_private_key, peer_b_public_key, peer_b_private_key
 
 
 class HandoffRemoteAsReciever(HandoffTestCase):

--- a/utils/captp_types.py
+++ b/utils/captp_types.py
@@ -16,7 +16,7 @@ from abc import ABC, abstractmethod
 from contrib import syrup
 from cryptography.exceptions import InvalidSignature
 from cryptography.hazmat.primitives.asymmetric.ed25519 import Ed25519PublicKey
-from utils.ocapn_uris import OCapNNode
+from utils.ocapn_uris import OCapNPeer
 
 from cryptography.hazmat.primitives import serialization
 
@@ -275,7 +275,7 @@ class DescHandoffGive(CapTPType):
     """
 
     def __init__(self, receiver_key: CapTPPublicKey,
-                 exporter_location: OCapNNode, session: bytes,
+                 exporter_location: OCapNPeer, session: bytes,
                  gifter_side: CapTPPublicKey, gift_id: bytes):
         self.receiver_key = receiver_key
         self.exporter_location = exporter_location
@@ -289,7 +289,7 @@ class DescHandoffGive(CapTPType):
         assert len(record.args) == 5
 
         receiver_key = CapTPPublicKey.from_syrup_record(record.args[0])
-        exporter_location = OCapNNode.from_syrup_record(record.args[1])
+        exporter_location = OCapNPeer.from_syrup_record(record.args[1])
 
         return cls(receiver_key, exporter_location, *record.args[2:])
 
@@ -346,7 +346,7 @@ class DescHandoffReceive(CapTPType):
 class OpStartSession(CapTPType):
     """ <op:start-session captp-version session-pubkey location location-sig> """
     def __init__(self, captp_version: str, session_pubkey: CapTPPublicKey,
-                 location: OCapNNode, location_sig: bytes):
+                 location: OCapNPeer, location_sig: bytes):
         self.captp_version = captp_version
         self.session_pubkey = session_pubkey
         self.location = location
@@ -599,7 +599,7 @@ CAPTP_TYPES = {
     syrup.Symbol("op:gc-answer"): OpGcAnswer,
 
     # OCapN URIs
-    syrup.Symbol("ocapn-node"): OCapNNode,
+    syrup.Symbol("ocapn-peer"): OCapNPeer,
 }
 
 

--- a/utils/ocapn_uris.py
+++ b/utils/ocapn_uris.py
@@ -26,8 +26,8 @@ class OCapNURI:
         return syrup_encode(self.to_syrup_record())
 
 
-class OCapNNode(OCapNURI):
-    """ <ocapn-node transport address hints> """
+class OCapNPeer(OCapNURI):
+    """ <ocapn-peer transport address hints> """
 
     def __init__(self, transport: Symbol, address: str, hints):
         self.transport = transport
@@ -35,7 +35,7 @@ class OCapNNode(OCapNURI):
         self.hints = hints
 
     def __eq__(self, other):
-        return isinstance(other, OCapNNode) and self.to_syrup() == other.to_syrup()
+        return isinstance(other, OCapNPeer) and self.to_syrup() == other.to_syrup()
 
     @classmethod
     def from_uri(cls, uri: str):
@@ -48,13 +48,13 @@ class OCapNNode(OCapNURI):
 
     @classmethod
     def from_syrup_record(cls, record: Record):
-        assert record.label == Symbol("ocapn-node")
+        assert record.label == Symbol("ocapn-peer")
         assert len(record.args) == 3
         return cls(*record.args)
 
     def to_syrup_record(self) -> Record:
         return Record(
-            Symbol("ocapn-node"),
+            Symbol("ocapn-peer"),
             [self.transport, self.address, self.hints]
         )
 
@@ -64,10 +64,10 @@ class OCapNNode(OCapNURI):
 
 
 class OCapNSturdyref(OCapNURI):
-    """ <ocapn-sturdyref ocapn-node swiss-num> """
+    """ <ocapn-sturdyref ocapn-peer swiss-num> """
 
-    def __init__(self, node, swiss_num):
-        self.node = node
+    def __init__(self, peer, swiss_num):
+        self.peer = peer
         self.swiss_num = swiss_num
 
     def __eq__(self, other):
@@ -77,15 +77,15 @@ class OCapNSturdyref(OCapNURI):
     def from_syrup_record(cls, record: Record):
         assert record.label == Symbol("ocapn-sturdyref")
         assert len(record.args) == 2
-        node = OCapNNode.from_syrup_record(record.args[0])
-        return cls(node, record.args[1])
+        peer = OCapNPeer.from_syrup_record(record.args[0])
+        return cls(peer, record.args[1])
 
     def to_syrup_record(self) -> Record:
         return Record(
             Symbol("ocapn-sturdyref"),
-            [self.node.to_syrup_record(), self.swiss_num]
+            [self.peer.to_syrup_record(), self.swiss_num]
         )
 
     def to_uri(self):
-        node_uri = self.node.to_uri()
-        return f"{node_uri}/s/{self.swiss_num}"
+        peer_uri = self.peer.to_uri()
+        return f"{peer_uri}/s/{self.swiss_num}"


### PR DESCRIPTION
In September 2024 the OCapN group took the decision to rename OCapN node to OCapN peer. This renames the locator to peer as per this agreement.