### PR TITLE
tests/op_abort: accept BrokenPipeError when peer closes write half

### DIFF
--- a/tests/op_abort.py
+++ b/tests/op_abort.py
@@ -28,7 +28,7 @@ class OpAbortTest(CapTPTestCase):
         abort_op = OpAbort("test-abort-before-setup")
         self.remote.send_message(abort_op)
 
-        with self.assertRaises((TimeoutError, ConnectionAbortedError)):
+        with self.assertRaises((TimeoutError, ConnectionAbortedError, BrokenPipeError)):
             # Now setup the session
             self.remote.setup_session(self.captp_version)
 


### PR DESCRIPTION
## Summary

`test_abort_before_setup` asserts the remote peer is unusable after receiving an unsolicited `op:abort`. The current `assertRaises` tuple covers `TimeoutError` and `ConnectionAbortedError`, but a compliant peer that closes its write half on inbound abort raises `BrokenPipeError` (errno 32) on the next `send_message` from this test — `fetch_object` writes a `<desc:export 0>` fetch frame, and the suite's `sendall` propagates the OS error verbatim.

`BrokenPipeError` is a subclass of `ConnectionError` (not `ConnectionAbortedError`), so it falls outside the current tuple despite being semantically the same outcome.

## Repro

```bash
# With a peer that closes its write half on inbound abort (verified against pancake-conformance-peer):
./test_runner.py 'ocapn://<swiss>.tcp-testing-only?host=127.0.0.1&port=22045' --verbose --test-module tests.op_abort
# Before this patch: ERROR (BrokenPipeError uncaught by assertRaises)
# After:             ok
```

## Test plan
- [ ] CI green
- [ ] Re-run against the reference Racket Goblins peer to confirm no regression there
